### PR TITLE
MOBILE-1086: Prevent FCModel crashes from occurring

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -596,7 +596,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 + (void)queryFailedInDatabase:(FMDatabase *)db
 {
-    NSLog(@"Query Failed in Database - %@", db.lastErrorMessage);
+    NSLog(@"[FCModel] query failed in database with error %@", db.lastErrorMessage);
 }
 
 #pragma mark - Attributes and CRUD
@@ -829,7 +829,10 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 {
     if (! checkForOpenDatabaseFatal(NO)) return FCModelSaveFailed;
 
-    if (deleted) [[NSException exceptionWithName:@"FCAttemptToSaveAfterDelete" reason:@"Cannot save deleted instance" userInfo:nil] raise];
+    if (deleted) {
+        NSLog(@"[FCModel] attempt to save after delete. Cannot save deleted instance.");
+        return FCModelSaveFailed;
+    }
 
     NSThread *sourceThread = NSThread.currentThread;
     __block FCModelSaveResult result;

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -836,7 +836,11 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     __block BOOL update;
     __block NSSet *changedFields = nil;
     [g_databaseQueue inDatabase:^(FMDatabase *db) {
-    
+        if (! checkForOpenDatabaseFatal(NO)) {
+            result = FCModelSaveFailed;
+            return;
+        }
+
         NSDictionary *changes = self.unsavedChanges;
         BOOL dirty = changes.count;
         if (! dirty && existsInDatabase) { result = FCModelSaveNoChanges; return; }

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -330,7 +330,12 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 + (NSError *)executeUpdateQuery:(NSString *)query, ...
 {
-    if (! checkForOpenDatabaseFatal(NO)) return nil;
+    if (! checkForOpenDatabaseFatal(NO)) {
+        NSDictionary *details = @{ NSLocalizedDescriptionKey: @"Database is closed" };
+        return [NSError errorWithDomain:@"FCModel"
+                                   code:NSURLErrorCannotOpenFile
+                               userInfo:details];
+    }
 
     va_list args;
     va_list *foolTheStaticAnalyzer = &args;
@@ -350,7 +355,12 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 + (NSError *)executeUpdateQuery:(NSString *)query arguments:(NSArray *)arguments
 {
-    if (! checkForOpenDatabaseFatal(NO)) return nil;
+    if (! checkForOpenDatabaseFatal(NO)) {
+        NSDictionary *details = @{ NSLocalizedDescriptionKey: @"Database is closed" };
+        return [NSError errorWithDomain:@"FCModel"
+                                   code:NSURLErrorCannotOpenFile
+                               userInfo:details];
+    }
 
     __block BOOL success = NO;
     __block NSError *error = nil;

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -596,7 +596,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 + (void)queryFailedInDatabase:(FMDatabase *)db
 {
-    [[NSException exceptionWithName:@"FCModelSQLiteException" reason:db.lastErrorMessage userInfo:nil] raise];
+    NSLog(@"Query Failed in Database - %@", db.lastErrorMessage);
 }
 
 #pragma mark - Attributes and CRUD


### PR DESCRIPTION
## Description

FCModel contains assertion checks that cause crashes when the database is not open.
## Proposed Changes

Changed the fatal asserts to instead fail gracefully when possible.
## Testing Suggestions
1. Create a database and close it
2. Attempt to execute a query. Should return an error instead of crashing.
