### PR TITLE
MOBILE-1523: iOS: Use cocoapods frameworks

### DIFF
--- a/FCModel.podspec
+++ b/FCModel.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/marcoarment/FCModel.git', :tag => s.version.to_s }
   s.source_files  = 'FCModel/*.{h,m}'
   s.requires_arc = true
-  s.dependency 'FMDB/SQLCiphher', '2.6.2'
+  s.dependency 'FMDB/SQLCipher', '2.6.2'
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
 end

--- a/FCModel.podspec
+++ b/FCModel.podspec
@@ -7,9 +7,8 @@ Pod::Spec.new do |s|
   s.author = { 'Marco Arment' => 'arment@marco.org' }
   s.source = { :git => 'https://github.com/marcoarment/FCModel.git', :tag => s.version.to_s }
   s.source_files  = 'FCModel/*.{h,m}'
-  s.library = 'sqlite3'
   s.requires_arc = true
-  s.dependency 'FMDB', '~> 2.1'
+  s.dependency 'FMDB/SQLCiphher', '2.6.2'
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
 end

--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -9,7 +9,7 @@
 #include <AvailabilityMacros.h>
 
 #ifdef COCOAPODS
-#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDB.h>
 #else
 #import "FMDatabase.h"
 #endif
@@ -223,4 +223,3 @@ inline __attribute__((always_inline)) void fcm_onMainThread(void (^block)())
         if (NSThread.isMainThread) block(); else dispatch_sync(dispatch_get_main_queue(), block);
     }
 }
-

--- a/FCModel/FCModelDatabase.h
+++ b/FCModel/FCModelDatabase.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #ifdef COCOAPODS
-#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDB.h>
 #else
 #import "FMDatabase.h"
 #endif


### PR DESCRIPTION
## This is CR 1 of 3, [wf-mobile-api](https://github.com/Workiva/wf-mobile-api/pull/68) [wdesk-ios](https://github.com/Workiva/wdesk-ios/pull/919)
## Description
- To use any third parties libraries written in swift through cocoapods, we must adopt the new pattern that transforms third party libraries into frameworks before they are pulled in to our app. This is done automatically by cocoapods but some of our existing libraries need to updated to be able to leverage this new framework way of doing things.
## What Was Changed
- Cocoapodsis now using version 1.0.0.beta5.
- Frameworks are now being used instead of static libraries for dependencies.
- All imports in tests for our testing frameworks (specta, expecta, and ocmock) are now in the precompiled header and all imports of these frameworks have been removed from all test files.
- FCModel has been updated to work with cocoapod frameworks.
- Removed all unused plugin files.
## Testing
1. Do a full clean of the wdesk-ios repo by running `git clean -xdff` from the top level directory.
2. Checkout `MOBILE-1528-test` (this has the updated version of the plugin tests)
3. Run grunt.
4. Ensure the app builds and runs and you can log in, set a pin, open the viewer, etc.
5. Ensure the unit tests pass on both iPhone and iPad.

---
